### PR TITLE
Timeout for image creation in config

### DIFF
--- a/builder/linode/builder_test.go
+++ b/builder/linode/builder_test.go
@@ -291,6 +291,46 @@ func TestBuilderPrepare_StateTimeout(t *testing.T) {
 	}
 }
 
+func TestBuilderPrepare_ImageCreateTimeout(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test default
+	_, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if b.config.ImageCreateTimeout != 10*time.Minute {
+		t.Errorf("invalid: %s", b.config.ImageCreateTimeout)
+	}
+
+	// Test set
+	config["image_create_timeout"] = "20m"
+	b = Builder{}
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	// Test bad
+	config["image_create_timeout"] = "tubes"
+	b = Builder{}
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+}
+
 func TestBuilderPrepare_AuthorizedKeys(t *testing.T) {
 	var b Builder
 	config := testConfig()

--- a/builder/linode/config.go
+++ b/builder/linode/config.go
@@ -25,17 +25,18 @@ type Config struct {
 
 	PersonalAccessToken string `mapstructure:"linode_token"`
 
-	Region         string        `mapstructure:"region"`
-	AuthorizedKeys []string      `mapstructure:"authorized_keys"`
-	InstanceType   string        `mapstructure:"instance_type"`
-	Label          string        `mapstructure:"instance_label"`
-	Tags           []string      `mapstructure:"instance_tags"`
-	Image          string        `mapstructure:"image"`
-	SwapSize       int           `mapstructure:"swap_size"`
-	RootPass       string        `mapstructure:"root_pass"`
-	ImageLabel     string        `mapstructure:"image_label"`
-	Description    string        `mapstructure:"image_description"`
-	StateTimeout   time.Duration `mapstructure:"state_timeout" required:"false"`
+	Region             string        `mapstructure:"region"`
+	AuthorizedKeys     []string      `mapstructure:"authorized_keys"`
+	InstanceType       string        `mapstructure:"instance_type"`
+	Label              string        `mapstructure:"instance_label"`
+	Tags               []string      `mapstructure:"instance_tags"`
+	Image              string        `mapstructure:"image"`
+	SwapSize           int           `mapstructure:"swap_size"`
+	RootPass           string        `mapstructure:"root_pass"`
+	ImageLabel         string        `mapstructure:"image_label"`
+	Description        string        `mapstructure:"image_description"`
+	StateTimeout       time.Duration `mapstructure:"state_timeout" required:"false"`
+	ImageCreateTimeout time.Duration `mapstructure:"image_create_timeout" required:"false"`
 }
 
 func createRandomRootPassword() (string, error) {
@@ -99,6 +100,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	if c.StateTimeout == 0 {
 		// Default to 5 minute timeouts waiting for state change
 		c.StateTimeout = 5 * time.Minute
+	}
+
+	if c.ImageCreateTimeout == 0 {
+		// Default to 10 minute timeouts waiting for image creation
+		c.ImageCreateTimeout = 10 * time.Minute
 	}
 
 	if es := c.Comm.Prepare(&c.ctx); len(es) > 0 {

--- a/builder/linode/config.hcl2spec.go
+++ b/builder/linode/config.hcl2spec.go
@@ -79,6 +79,7 @@ type FlatConfig struct {
 	ImageLabel                *string           `mapstructure:"image_label" cty:"image_label" hcl:"image_label"`
 	Description               *string           `mapstructure:"image_description" cty:"image_description" hcl:"image_description"`
 	StateTimeout              *string           `mapstructure:"state_timeout" required:"false" cty:"state_timeout" hcl:"state_timeout"`
+	ImageCreateTimeout        *string           `mapstructure:"image_create_timeout" required:"false" cty:"image_create_timeout" hcl:"image_create_timeout"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -162,6 +163,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_label":                  &hcldec.AttrSpec{Name: "image_label", Type: cty.String, Required: false},
 		"image_description":            &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"state_timeout":                &hcldec.AttrSpec{Name: "state_timeout", Type: cty.String, Required: false},
+		"image_create_timeout":         &hcldec.AttrSpec{Name: "image_create_timeout", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/linode/step_create_image.go
+++ b/builder/linode/step_create_image.go
@@ -27,7 +27,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	})
 
 	if err == nil {
-		_, err = s.client.WaitForInstanceDiskStatus(ctx, instance.ID, disk.ID, linodego.DiskReady, 600)
+		_, err = s.client.WaitForInstanceDiskStatus(ctx, instance.ID, disk.ID, linodego.DiskReady, int(c.ImageCreateTimeout.Seconds()))
 	}
 
 	if err == nil {

--- a/docs/builders/linode.mdx
+++ b/docs/builders/linode.mdx
@@ -98,6 +98,10 @@ can also be supplied to override the typical auto-generated key:
   Linode instance to enter a desired state (such as "running") before timing
   out. The default state timeout is "5m".
 
+- image_create_timeout (string) - The time to wait, as a duration string, for the
+  disk image to be created successfully before timing out.
+  The default image creation timeout is "10m".
+
 ## Basic Example
 
 Here is a Linode builder example. The `linode_token` should be replaced with an


### PR DESCRIPTION
Hello,

We are currently working with quite large images in Linode (~20 GB) and often experience timeouts during image creation. I've added a timeout configuration variable so we can increase it for our workflow.

Could you please review this pull request and provide any comments or suggestions? If everything looks good, please consider merging it.

Thank you!