### PR TITLE
ref: Update workflows to point at both `dev` and `main` branches

### DIFF
--- a/.github/workflows/go-test-darwin.yml
+++ b/.github/workflows/go-test-darwin.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'dev'
   pull_request:
 
 permissions:

--- a/.github/workflows/go-test-linux.yml
+++ b/.github/workflows/go-test-linux.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'dev'
   pull_request:
 
 permissions:

--- a/.github/workflows/go-test-windows.yml
+++ b/.github/workflows/go-test-windows.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'dev'
   pull_request:
 
 permissions:

--- a/.github/workflows/go-validate.yml
+++ b/.github/workflows/go-validate.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'dev'
   pull_request:
 
 permissions:


### PR DESCRIPTION
## 📝 Description

This change updates certain workflows to point at both the `dev` and `main` branches. This change allows us to switch to the `dev`/`main` branch model used by other Linode repositories.
