### PR TITLE
Let dependabot update all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
@@ -9,7 +9,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    allow:
-      - dependency-name: "github.com/hashicorp/packer-plugin-sdk"
-      - dependency-name: "github.com/hashicorp/hcl/v2"
-      - dependency-name: "github.com/zclconf/go-cty"


### PR DESCRIPTION
## 📝 Description

Previously the dependabot is only allowed to update a subset of the dependencies. Update it to allow all dependency updates.
