### PR TITLE
Docs: token can be set in env; added available regions and linode types list

### DIFF
--- a/docs/builders/linode.mdx
+++ b/docs/builders/linode.mdx
@@ -60,6 +60,8 @@ can also be supplied to override the typical auto-generated key:
 ### Required
 
 - `linode_token` (string) - The client TOKEN to use to access your account.
+  Alternatively, you can set your token as an environment variable name
+  `LINODE_TOKEN`.
 
 - `image` (string) - An Image ID to deploy the Disk from. Official Linode
   Images start with `linode/`, while user Images start with `private/`. See

--- a/docs/builders/linode.mdx
+++ b/docs/builders/linode.mdx
@@ -71,13 +71,15 @@ can also be supplied to override the typical auto-generated key:
 
 - `region` (string) - The id of the region to launch the Linode instance in.
   Images are available in all regions, but there will be less delay when
-  deploying from the region where the image was taken. Examples are
-  `us-east`, `us-central`, `us-west`, `ap-south`, `ca-east`, `ap-northeast`,
-  `eu-central`, and `eu-west`.
+  deploying from the region where the image was taken. See
+  [regions](https://api.linode.com/v4/regions) for more information on the
+  available regions. Examples are `us-east`, `us-central`, `us-west`,
+  `ap-south`, `ca-east`, `ap-northeast`, `eu-central`, and `eu-west`.
 
 - `instance_type` (string) - The Linode type defines the pricing, CPU, disk,
-  and RAM specs of the instance. Examples are `g6-nanode-1`, `g6-standard-2`,
-  `g6-highmem-16`, and `g6-dedicated-16`.
+  and RAM specs of the instance. See [instance types](https://api.linode.com/v4/linode/types)
+  for more information on the available Linode instance types. Examples are `g6-nanode-1`,
+  `g6-standard-2`, `g6-highmem-16`, and `g6-dedicated-16`.
 
 ### Optional
 

--- a/docs/builders/linode.mdx
+++ b/docs/builders/linode.mdx
@@ -60,7 +60,7 @@ can also be supplied to override the typical auto-generated key:
 ### Required
 
 - `linode_token` (string) - The client TOKEN to use to access your account.
-  Alternatively, you can set your token as an environment variable name
+ Alternatively, you can set your token as an environment variable named
   `LINODE_TOKEN`.
 
 - `image` (string) - An Image ID to deploy the Disk from. Official Linode


### PR DESCRIPTION
## 📝 Description

This is to let the users know they don't have to set the token in the config file. They can set it in the env var instead.