### PR TITLE
Add `authorized_users` field

### DIFF
--- a/builder/linode/builder_test.go
+++ b/builder/linode/builder_test.go
@@ -329,12 +329,14 @@ func TestBuilderPrepare_ImageCreateTimeout(t *testing.T) {
 	}
 }
 
-func TestBuilderPrepare_AuthorizedKeys(t *testing.T) {
+func TestBuilderPrepare_AuthorizedKeysAndUsers(t *testing.T) {
 	var b Builder
 	config := testConfig()
 
 	// Test optional
 	delete(config, "authorized_keys")
+	delete(config, "authorized_users")
+
 	_, warnings, err := b.Prepare(config)
 	if len(warnings) > 0 {
 		t.Fatalf("bad: %#v", warnings)
@@ -343,12 +345,18 @@ func TestBuilderPrepare_AuthorizedKeys(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := []string{
+	expectedKeys := []string{
 		"ssh-rsa test@test",
 	}
 
+	expectedUsers := []string{
+		"my_user1",
+		"my_user2",
+	}
+
 	// Test set
-	config["authorized_keys"] = expected
+	config["authorized_keys"] = expectedKeys
+	config["authorized_users"] = expectedUsers
 	b = Builder{}
 	_, warnings, err = b.Prepare(config)
 	if len(warnings) > 0 {
@@ -358,7 +366,10 @@ func TestBuilderPrepare_AuthorizedKeys(t *testing.T) {
 		t.Fatalf("should not have error: %s", err)
 	}
 
-	if !reflect.DeepEqual(b.config.AuthorizedKeys, expected) {
-		t.Errorf("got %v, expected %v", b.config.AuthorizedKeys, expected)
+	if !reflect.DeepEqual(b.config.AuthorizedKeys, expectedKeys) {
+		t.Errorf("got %v, expected %v", b.config.AuthorizedKeys, expectedKeys)
+	}
+	if !reflect.DeepEqual(b.config.AuthorizedUsers, expectedUsers) {
+		t.Errorf("got %v, expected %v", b.config.AuthorizedKeys, expectedUsers)
 	}
 }

--- a/builder/linode/config.go
+++ b/builder/linode/config.go
@@ -27,6 +27,7 @@ type Config struct {
 
 	Region             string        `mapstructure:"region"`
 	AuthorizedKeys     []string      `mapstructure:"authorized_keys"`
+	AuthorizedUsers    []string      `mapstructure:"authorized_users"`
 	InstanceType       string        `mapstructure:"instance_type"`
 	Label              string        `mapstructure:"instance_label"`
 	Tags               []string      `mapstructure:"instance_tags"`

--- a/builder/linode/config.hcl2spec.go
+++ b/builder/linode/config.hcl2spec.go
@@ -70,6 +70,7 @@ type FlatConfig struct {
 	PersonalAccessToken       *string           `mapstructure:"linode_token" cty:"linode_token" hcl:"linode_token"`
 	Region                    *string           `mapstructure:"region" cty:"region" hcl:"region"`
 	AuthorizedKeys            []string          `mapstructure:"authorized_keys" cty:"authorized_keys" hcl:"authorized_keys"`
+	AuthorizedUsers           []string          `mapstructure:"authorized_users" cty:"authorized_users" hcl:"authorized_users"`
 	InstanceType              *string           `mapstructure:"instance_type" cty:"instance_type" hcl:"instance_type"`
 	Label                     *string           `mapstructure:"instance_label" cty:"instance_label" hcl:"instance_label"`
 	Tags                      []string          `mapstructure:"instance_tags" cty:"instance_tags" hcl:"instance_tags"`
@@ -154,6 +155,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"linode_token":                 &hcldec.AttrSpec{Name: "linode_token", Type: cty.String, Required: false},
 		"region":                       &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"authorized_keys":              &hcldec.AttrSpec{Name: "authorized_keys", Type: cty.List(cty.String), Required: false},
+		"authorized_users":             &hcldec.AttrSpec{Name: "authorized_users", Type: cty.List(cty.String), Required: false},
 		"instance_type":                &hcldec.AttrSpec{Name: "instance_type", Type: cty.String, Required: false},
 		"instance_label":               &hcldec.AttrSpec{Name: "instance_label", Type: cty.String, Required: false},
 		"instance_tags":                &hcldec.AttrSpec{Name: "instance_tags", Type: cty.List(cty.String), Required: false},

--- a/builder/linode/step_create_linode.go
+++ b/builder/linode/step_create_linode.go
@@ -21,13 +21,14 @@ func (s *stepCreateLinode) Run(ctx context.Context, state multistep.StateBag) mu
 	ui.Say("Creating Linode...")
 
 	createOpts := linodego.InstanceCreateOptions{
-		RootPass:       c.Comm.Password(),
-		AuthorizedKeys: []string{},
-		Region:         c.Region,
-		Type:           c.InstanceType,
-		Label:          c.Label,
-		Image:          c.Image,
-		SwapSize:       &c.SwapSize,
+		RootPass:        c.Comm.Password(),
+		AuthorizedKeys:  []string{},
+		AuthorizedUsers: []string{},
+		Region:          c.Region,
+		Type:            c.InstanceType,
+		Label:           c.Label,
+		Image:           c.Image,
+		SwapSize:        &c.SwapSize,
 	}
 
 	if pubKey := string(c.Comm.SSHPublicKey); pubKey != "" {
@@ -35,6 +36,7 @@ func (s *stepCreateLinode) Run(ctx context.Context, state multistep.StateBag) mu
 	}
 
 	createOpts.AuthorizedKeys = append(createOpts.AuthorizedKeys, c.AuthorizedKeys...)
+	createOpts.AuthorizedUsers = append(createOpts.AuthorizedUsers, c.AuthorizedUsers...)
 
 	instance, err := s.client.CreateInstance(ctx, createOpts)
 	if err != nil {


### PR DESCRIPTION
## 📝 Description

Allow the image to have the ssk keys from the Linode user.

## ✔️ How to Test

1. Add some ssh keys into your Linode user profile.
https://www.linode.com/docs/api/profile/#ssh-key-add
2. Clone the repo and checkout my branch then build this version of packer plugin by `make build`.
3. Follow the [documented instructions](https://developer.hashicorp.com/packer/docs/plugins/creation#testing-plugins) to run the locally built packer plugin with a simple packer config file as below. Basically two commands, `packer init .` and `packer build .`. Don't forget add your username to the newly added `authorized_users` field.

file `test.pkr.hcl`
```
locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }

source "linode" "example" {
  
  image_label       = "private-image-${local.timestamp}"
  instance_label    = "temporary-linode-${local.timestamp}"
  authorized_users  = ["your_username_here"]
  instance_type     = "g6-standard-1"
  region            = "us-central"
  image             = "linode/ubuntu22.04"
  ssh_username      = "root"
}

build {
  sources = ["source.linode.example"]
}

```
4. Verify if the image has been created on your Linode account.
https://www.linode.com/docs/api/images/#images-list
5. Create a linode with that private image.
<img width="634" alt="image" src="https://user-images.githubusercontent.com/121905282/235559709-b731bf9f-df4e-4038-be46-d331acaf7d9d.png">

6. Login (SSH) into your linode and ensure the ssh key in your user profile has been added into the linode.
You can view the list of ssh keys in the linode by this command, `cat ~/.ssh/authorized_keys` 