### PR TITLE
Add Interfaces, PrivateIP, StackScriptData, StackScriptID arguments

### DIFF
--- a/builder/linode/builder_test.go
+++ b/builder/linode/builder_test.go
@@ -373,3 +373,132 @@ func TestBuilderPrepare_AuthorizedKeysAndUsers(t *testing.T) {
 		t.Errorf("got %v, expected %v", b.config.AuthorizedKeys, expectedUsers)
 	}
 }
+
+func TestBuilderPrepare_PrivateIP(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test optional
+	delete(config, "private_ip")
+
+	_, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedPrivateIP := true
+	config["private_ip"] = expectedPrivateIP
+
+	b = Builder{}
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if !reflect.DeepEqual(b.config.PrivateIP, expectedPrivateIP) {
+		t.Errorf("got %v, expected %v", b.config.PrivateIP, expectedPrivateIP)
+	}
+}
+
+func TestBuilderPrepare_StackScripts(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test optional
+	delete(config, "stackscript_id")
+	delete(config, "stackscript_data")
+
+	_, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedStackScriptID := 123
+	expectedStackScriptData := map[string]string{"test_data": "test_value"}
+
+	// Test set
+	config["stackscript_id"] = expectedStackScriptID
+	config["stackscript_data"] = expectedStackScriptData
+	b = Builder{}
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if !reflect.DeepEqual(b.config.StackScriptID, expectedStackScriptID) {
+		t.Errorf(
+			"got %v, expected %v",
+			b.config.StackScriptID,
+			expectedStackScriptID,
+		)
+	}
+	if !reflect.DeepEqual(b.config.StackScriptData, expectedStackScriptData) {
+		t.Errorf(
+			"got %v, expected %v",
+			b.config.StackScriptData,
+			expectedStackScriptData,
+		)
+	}
+}
+
+func TestBuilderPrepare_NetworkInterfaces(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test optional
+	delete(config, "interface")
+	delete(config, "authorized_users")
+
+	_, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedInterfaces := []Interface{
+		{
+			Purpose:     "public",
+			Label:       "",
+			IPAMAddress: "",
+		},
+		{
+			Purpose:     "vlan",
+			Label:       "vlan-1",
+			IPAMAddress: "10.0.0.1/24",
+		},
+		{
+			Purpose:     "vlan",
+			Label:       "vlan-2",
+			IPAMAddress: "10.0.0.2/24",
+		},
+	}
+
+	// Test set
+	config["interface"] = expectedInterfaces
+	b = Builder{}
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	if !reflect.DeepEqual(b.config.Interfaces, expectedInterfaces) {
+		t.Errorf("got %v, expected %v", b.config.Interfaces, expectedInterfaces)
+	}
+}

--- a/builder/linode/config.go
+++ b/builder/linode/config.go
@@ -1,4 +1,4 @@
-//go:generate packer-sdc mapstructure-to-hcl2 -type Config,Interfaces
+//go:generate packer-sdc mapstructure-to-hcl2 -type Config,Interface
 
 package linode
 
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
-type Interfaces struct {
+type Interface struct {
 	Purpose     string `mapstructure:"purpose"`
 	Label       string `mapstructure:"label"`
 	IPAMAddress string `mapstructure:"ipam_address"`
@@ -31,7 +31,7 @@ type Config struct {
 
 	PersonalAccessToken string `mapstructure:"linode_token"`
 
-	Interfaces         []Interfaces      `mapstructure:"interface"`
+	Interfaces         []Interface       `mapstructure:"interface"`
 	Region             string            `mapstructure:"region"`
 	AuthorizedKeys     []string          `mapstructure:"authorized_keys"`
 	AuthorizedUsers    []string          `mapstructure:"authorized_users"`

--- a/builder/linode/config.go
+++ b/builder/linode/config.go
@@ -1,4 +1,4 @@
-//go:generate packer-sdc mapstructure-to-hcl2 -type Config
+//go:generate packer-sdc mapstructure-to-hcl2 -type Config,Interfaces
 
 package linode
 
@@ -18,6 +18,12 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
+type Interfaces struct {
+	Purpose     string `mapstructure:"purpose"`
+	Label       string `mapstructure:"label"`
+	IPAMAddress string `mapstructure:"ipam_address"`
+}
+
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 	ctx                 interpolate.Context
@@ -25,26 +31,30 @@ type Config struct {
 
 	PersonalAccessToken string `mapstructure:"linode_token"`
 
-	Region             string        `mapstructure:"region"`
-	AuthorizedKeys     []string      `mapstructure:"authorized_keys"`
-	AuthorizedUsers    []string      `mapstructure:"authorized_users"`
-	InstanceType       string        `mapstructure:"instance_type"`
-	Label              string        `mapstructure:"instance_label"`
-	Tags               []string      `mapstructure:"instance_tags"`
-	Image              string        `mapstructure:"image"`
-	SwapSize           int           `mapstructure:"swap_size"`
-	RootPass           string        `mapstructure:"root_pass"`
-	ImageLabel         string        `mapstructure:"image_label"`
-	Description        string        `mapstructure:"image_description"`
-	StateTimeout       time.Duration `mapstructure:"state_timeout" required:"false"`
-	ImageCreateTimeout time.Duration `mapstructure:"image_create_timeout" required:"false"`
+	Interfaces         []Interfaces      `mapstructure:"interface"`
+	Region             string            `mapstructure:"region"`
+	AuthorizedKeys     []string          `mapstructure:"authorized_keys"`
+	AuthorizedUsers    []string          `mapstructure:"authorized_users"`
+	InstanceType       string            `mapstructure:"instance_type"`
+	Label              string            `mapstructure:"instance_label"`
+	Tags               []string          `mapstructure:"instance_tags"`
+	Image              string            `mapstructure:"image"`
+	SwapSize           int               `mapstructure:"swap_size"`
+	PrivateIP          bool              `mapstructure:"private_ip"`
+	RootPass           string            `mapstructure:"root_pass"`
+	ImageLabel         string            `mapstructure:"image_label"`
+	Description        string            `mapstructure:"image_description"`
+	StateTimeout       time.Duration     `mapstructure:"state_timeout" required:"false"`
+	StackScriptData    map[string]string `mapstructure:"stackscript_data"`
+	StackScriptID      int               `mapstructure:"stackscript_id"`
+	ImageCreateTimeout time.Duration     `mapstructure:"image_create_timeout" required:"false"`
 }
 
 func createRandomRootPassword() (string, error) {
 	rawRootPass := make([]byte, 50)
 	_, err := rand.Read(rawRootPass)
 	if err != nil {
-		return "", fmt.Errorf("Failed to generate random password")
+		return "", fmt.Errorf("failed to generate random password")
 	}
 	rootPass := base64.StdEncoding.EncodeToString(rawRootPass)
 	return rootPass, nil

--- a/builder/linode/config.hcl2spec.go
+++ b/builder/linode/config.hcl2spec.go
@@ -68,6 +68,7 @@ type FlatConfig struct {
 	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
 	PersonalAccessToken       *string           `mapstructure:"linode_token" cty:"linode_token" hcl:"linode_token"`
+	Interfaces                []FlatInterfaces  `mapstructure:"interface" cty:"interface" hcl:"interface"`
 	Region                    *string           `mapstructure:"region" cty:"region" hcl:"region"`
 	AuthorizedKeys            []string          `mapstructure:"authorized_keys" cty:"authorized_keys" hcl:"authorized_keys"`
 	AuthorizedUsers           []string          `mapstructure:"authorized_users" cty:"authorized_users" hcl:"authorized_users"`
@@ -76,10 +77,13 @@ type FlatConfig struct {
 	Tags                      []string          `mapstructure:"instance_tags" cty:"instance_tags" hcl:"instance_tags"`
 	Image                     *string           `mapstructure:"image" cty:"image" hcl:"image"`
 	SwapSize                  *int              `mapstructure:"swap_size" cty:"swap_size" hcl:"swap_size"`
+	PrivateIP                 *bool             `mapstructure:"private_ip" cty:"private_ip" hcl:"private_ip"`
 	RootPass                  *string           `mapstructure:"root_pass" cty:"root_pass" hcl:"root_pass"`
 	ImageLabel                *string           `mapstructure:"image_label" cty:"image_label" hcl:"image_label"`
 	Description               *string           `mapstructure:"image_description" cty:"image_description" hcl:"image_description"`
 	StateTimeout              *string           `mapstructure:"state_timeout" required:"false" cty:"state_timeout" hcl:"state_timeout"`
+	StackScriptData           map[string]string `mapstructure:"stackscript_data" cty:"stackscript_data" hcl:"stackscript_data"`
+	StackScriptID             *int              `mapstructure:"stackscript_id" cty:"stackscript_id" hcl:"stackscript_id"`
 	ImageCreateTimeout        *string           `mapstructure:"image_create_timeout" required:"false" cty:"image_create_timeout" hcl:"image_create_timeout"`
 }
 
@@ -153,6 +157,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_insecure":               &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
 		"linode_token":                 &hcldec.AttrSpec{Name: "linode_token", Type: cty.String, Required: false},
+		"interface":                    &hcldec.BlockListSpec{TypeName: "interface", Nested: hcldec.ObjectSpec((*FlatInterfaces)(nil).HCL2Spec())},
 		"region":                       &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"authorized_keys":              &hcldec.AttrSpec{Name: "authorized_keys", Type: cty.List(cty.String), Required: false},
 		"authorized_users":             &hcldec.AttrSpec{Name: "authorized_users", Type: cty.List(cty.String), Required: false},
@@ -161,11 +166,41 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"instance_tags":                &hcldec.AttrSpec{Name: "instance_tags", Type: cty.List(cty.String), Required: false},
 		"image":                        &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},
 		"swap_size":                    &hcldec.AttrSpec{Name: "swap_size", Type: cty.Number, Required: false},
+		"private_ip":                   &hcldec.AttrSpec{Name: "private_ip", Type: cty.Bool, Required: false},
 		"root_pass":                    &hcldec.AttrSpec{Name: "root_pass", Type: cty.String, Required: false},
 		"image_label":                  &hcldec.AttrSpec{Name: "image_label", Type: cty.String, Required: false},
 		"image_description":            &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"state_timeout":                &hcldec.AttrSpec{Name: "state_timeout", Type: cty.String, Required: false},
+		"stackscript_data":             &hcldec.AttrSpec{Name: "stackscript_data", Type: cty.Map(cty.String), Required: false},
+		"stackscript_id":               &hcldec.AttrSpec{Name: "stackscript_id", Type: cty.Number, Required: false},
 		"image_create_timeout":         &hcldec.AttrSpec{Name: "image_create_timeout", Type: cty.String, Required: false},
+	}
+	return s
+}
+
+// FlatInterfaces is an auto-generated flat version of Interfaces.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatInterfaces struct {
+	Purpose     *string `mapstructure:"purpose" cty:"purpose" hcl:"purpose"`
+	Label       *string `mapstructure:"label" cty:"label" hcl:"label"`
+	IPAMAddress *string `mapstructure:"ipam_address" cty:"ipam_address" hcl:"ipam_address"`
+}
+
+// FlatMapstructure returns a new FlatInterfaces.
+// FlatInterfaces is an auto-generated flat version of Interfaces.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*Interfaces) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatInterfaces)
+}
+
+// HCL2Spec returns the hcl spec of a Interfaces.
+// This spec is used by HCL to read the fields of Interfaces.
+// The decoded values from this spec will then be applied to a FlatInterfaces.
+func (*FlatInterfaces) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"purpose":      &hcldec.AttrSpec{Name: "purpose", Type: cty.String, Required: false},
+		"label":        &hcldec.AttrSpec{Name: "label", Type: cty.String, Required: false},
+		"ipam_address": &hcldec.AttrSpec{Name: "ipam_address", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/linode/config.hcl2spec.go
+++ b/builder/linode/config.hcl2spec.go
@@ -68,7 +68,7 @@ type FlatConfig struct {
 	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
 	PersonalAccessToken       *string           `mapstructure:"linode_token" cty:"linode_token" hcl:"linode_token"`
-	Interfaces                []FlatInterfaces  `mapstructure:"interface" cty:"interface" hcl:"interface"`
+	Interfaces                []FlatInterface   `mapstructure:"interface" cty:"interface" hcl:"interface"`
 	Region                    *string           `mapstructure:"region" cty:"region" hcl:"region"`
 	AuthorizedKeys            []string          `mapstructure:"authorized_keys" cty:"authorized_keys" hcl:"authorized_keys"`
 	AuthorizedUsers           []string          `mapstructure:"authorized_users" cty:"authorized_users" hcl:"authorized_users"`
@@ -157,7 +157,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_insecure":               &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
 		"linode_token":                 &hcldec.AttrSpec{Name: "linode_token", Type: cty.String, Required: false},
-		"interface":                    &hcldec.BlockListSpec{TypeName: "interface", Nested: hcldec.ObjectSpec((*FlatInterfaces)(nil).HCL2Spec())},
+		"interface":                    &hcldec.BlockListSpec{TypeName: "interface", Nested: hcldec.ObjectSpec((*FlatInterface)(nil).HCL2Spec())},
 		"region":                       &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"authorized_keys":              &hcldec.AttrSpec{Name: "authorized_keys", Type: cty.List(cty.String), Required: false},
 		"authorized_users":             &hcldec.AttrSpec{Name: "authorized_users", Type: cty.List(cty.String), Required: false},
@@ -178,25 +178,25 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 	return s
 }
 
-// FlatInterfaces is an auto-generated flat version of Interfaces.
+// FlatInterface is an auto-generated flat version of Interface.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
-type FlatInterfaces struct {
+type FlatInterface struct {
 	Purpose     *string `mapstructure:"purpose" cty:"purpose" hcl:"purpose"`
 	Label       *string `mapstructure:"label" cty:"label" hcl:"label"`
 	IPAMAddress *string `mapstructure:"ipam_address" cty:"ipam_address" hcl:"ipam_address"`
 }
 
-// FlatMapstructure returns a new FlatInterfaces.
-// FlatInterfaces is an auto-generated flat version of Interfaces.
+// FlatMapstructure returns a new FlatInterface.
+// FlatInterface is an auto-generated flat version of Interface.
 // Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
-func (*Interfaces) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
-	return new(FlatInterfaces)
+func (*Interface) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatInterface)
 }
 
-// HCL2Spec returns the hcl spec of a Interfaces.
-// This spec is used by HCL to read the fields of Interfaces.
-// The decoded values from this spec will then be applied to a FlatInterfaces.
-func (*FlatInterfaces) HCL2Spec() map[string]hcldec.Spec {
+// HCL2Spec returns the hcl spec of a Interface.
+// This spec is used by HCL to read the fields of Interface.
+// The decoded values from this spec will then be applied to a FlatInterface.
+func (*FlatInterface) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"purpose":      &hcldec.AttrSpec{Name: "purpose", Type: cty.String, Required: false},
 		"label":        &hcldec.AttrSpec{Name: "label", Type: cty.String, Required: false},

--- a/builder/linode/step_create_linode.go
+++ b/builder/linode/step_create_linode.go
@@ -13,6 +13,14 @@ type stepCreateLinode struct {
 	client linodego.Client
 }
 
+func flattenConfigInterface(i Interfaces) linodego.InstanceConfigInterface {
+	return linodego.InstanceConfigInterface{
+		IPAMAddress: i.IPAMAddress,
+		Label:       i.Label,
+		Purpose:     linodego.ConfigInterfacePurpose(i.Purpose),
+	}
+}
+
 func (s *stepCreateLinode) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	c := state.Get("config").(*Config)
 	ui := state.Get("ui").(packersdk.Ui)
@@ -23,11 +31,20 @@ func (s *stepCreateLinode) Run(ctx context.Context, state multistep.StateBag) mu
 
 	ui.Say("Creating Linode...")
 
+	interfaces := make([]linodego.InstanceConfigInterface, len(c.Interfaces))
+	for i, v := range c.Interfaces {
+		interfaces[i] = flattenConfigInterface(v)
+	}
+
 	createOpts := linodego.InstanceCreateOptions{
 		RootPass:        c.Comm.Password(),
 		AuthorizedKeys:  []string{},
 		AuthorizedUsers: []string{},
+		Interfaces:      interfaces,
+		PrivateIP:       c.PrivateIP,
 		Region:          c.Region,
+		StackScriptID:   c.StackScriptID,
+		StackScriptData: c.StackScriptData,
 		Type:            c.InstanceType,
 		Label:           c.Label,
 		Image:           c.Image,

--- a/builder/linode/step_create_linode.go
+++ b/builder/linode/step_create_linode.go
@@ -13,7 +13,7 @@ type stepCreateLinode struct {
 	client linodego.Client
 }
 
-func flattenConfigInterface(i Interfaces) linodego.InstanceConfigInterface {
+func flattenConfigInterface(i Interface) linodego.InstanceConfigInterface {
 	return linodego.InstanceConfigInterface{
 		IPAMAddress: i.IPAMAddress,
 		Label:       i.Label,

--- a/docs/builders/linode.mdx
+++ b/docs/builders/linode.mdx
@@ -129,7 +129,7 @@ Token](https://www.linode.com/docs/platform/api/getting-started-with-the-linode-
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "linode" "example" {
-  image             = "linode/debian9"
+  image             = "linode/debian11"
   image_description = "My Private Image"
   image_label       = "private-image-${local.timestamp}"
   instance_label    = "temporary-linode-${local.timestamp}"
@@ -176,17 +176,52 @@ build {
 
 ```json
 {
-  "type": "linode",
-  "linode_token": "YOUR API TOKEN",
-  "image": "linode/debian9",
-  "region": "us-east",
-  "instance_type": "g6-nanode-1",
-  "instance_label": "temporary-linode-{{timestamp}}",
-
-  "image_label": "private-image-{{timestamp}}",
-  "image_description": "My Private Image",
-
-  "ssh_username": "root"
+  "source": {
+    "linode": {
+      "example": {
+        "image": "linode/debian11",
+        "region": "us-southeast",
+        "instance_type": "g6-nanode-1",
+        "instance_label": "temporary-linode-{{timestamp}}",
+        "private_ip": true,
+        "image_label": "private-image-{{timestamp}}",
+        "image_description": "My Private Image",
+        "ssh_username": "root",
+        "authorized_users": [
+          "your_authorized_username"
+        ],
+        "authorized_keys": [
+          "ssh-rsa AAAA_valid_public_ssh_key_123456785== user@their-computer"
+        ],
+        "stackscript_id": 123,
+        "stackscript_data": {
+          "test_data": "test_value"
+        },
+        "interface": [
+          {
+            "purpose": "public",
+            "label": "",
+            "ipam_address": ""
+          },
+          {
+            "purpose": "vlan",
+            "label": "vlan-1",
+            "ipam_address": "10.0.0.1/24"
+          },
+          {
+            "purpose": "vlan",
+            "label": "vlan-2",
+            "ipam_address": "10.0.0.2/24"
+          }
+        ]
+      }
+    }
+  },
+  "build": {
+    "sources": [
+      "source.linode.example"
+    ]
+  }
 }
 ```
 

--- a/docs/builders/linode.mdx
+++ b/docs/builders/linode.mdx
@@ -83,13 +83,19 @@ can also be supplied to override the typical auto-generated key:
 
 ### Optional
 
-- `authorized_keys` (list) - Public SSH keys to be appended to the Linode instance.
+- `authorized_keys` (list) - Public SSH keys need to be appended to the Linode instance.
+
+- `authorized_users` (list) - Users whose SSH keys need to be appended to the Linode instance.
 
 - `instance_label` (string) - The name assigned to the Linode Instance.
 
 - `instance_tags` (list) - Tags to apply to the instance when it is created.
 
 - `swap_size` (int) - The disk size (MiB) allocated for swap space.
+
+- `interface` ([]{purpose string, label string, ipam_address string}) - Network Interfaces
+  to add to this Linode’s Configuration Profile. Singular repeatable block containing a `purpose`,
+  a `label`, and an `ipam_address` field.
 
 - `image_label` (string) - The name of the resulting image that will appear
   in your account. Defaults to `packer-{{timestamp}}` (see [configuration
@@ -102,9 +108,12 @@ can also be supplied to override the typical auto-generated key:
   Linode instance to enter a desired state (such as "running") before timing
   out. The default state timeout is "5m".
 
-- image_create_timeout (string) - The time to wait, as a duration string, for the
+- `image_create_timeout` (string) - The time to wait, as a duration string, for the
   disk image to be created successfully before timing out.
   The default image creation timeout is "10m".
+
+- `private_ip` (bool) - If true, the created Linode will have private networking
+  enabled and assigned a private IPv4 address.
 
 ## Basic Example
 
@@ -128,6 +137,32 @@ source "linode" "example" {
   linode_token      = "YOUR API TOKEN"
   region            = "us-east"
   ssh_username      = "root"
+  private_ip        = true
+
+  authorized_users  = ["your_authorized_username"]
+  authorized_keys   = ["ssh-rsa AAAA_valid_public_ssh_key_123456785== user@their-computer"]
+  stackscript_id    = 1177256
+  stackscript_data  = {
+    "test_key": "test_value_1"
+  }
+
+  interface {
+    purpose       = "public"
+    label         = ""
+    ipam_address  = ""
+  }
+
+  interface {
+    purpose       = "vlan"
+    label         = "vlan-1"
+    ipam_address  = "10.0.0.1/24"
+  }
+
+  interface {
+    purpose       = "vlan"
+    label         = "vlan-2"
+    ipam_address  = "10.0.0.2/24"
+  }
 }
 
 build {

--- a/docs/builders/linode.mdx
+++ b/docs/builders/linode.mdx
@@ -115,11 +115,70 @@ can also be supplied to override the typical auto-generated key:
 - `private_ip` (bool) - If true, the created Linode will have private networking
   enabled and assigned a private IPv4 address.
 
-## Basic Example
+## Examples
+
+### Basic Example
 
 Here is a Linode builder example. The `linode_token` should be replaced with an
 actual [Linode Personal Access
-Token](https://www.linode.com/docs/platform/api/getting-started-with-the-linode-api/#get-an-access-token).
+Token](https://www.linode.com/docs/platform/api/getting-started-with-the-linode-api/#get-an-access-token)
+or in the config file or the environmental variable, `LINODE_TOKEN`.
+
+<Tabs>
+<Tab heading="HCL2">
+
+```hcl
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "linode" "example" {
+  image             = "linode/debian11"
+  image_description = "My Private Image"
+  image_label       = "private-image-${local.timestamp}"
+  instance_label    = "temporary-linode-${local.timestamp}"
+  instance_type     = "g6-nanode-1"
+  linode_token      = "YOUR API TOKEN"
+  region            = "us-east"
+  ssh_username      = "root"
+}
+
+build {
+  sources = ["source.linode.example"]
+}
+
+```
+
+</Tab>
+<Tab heading="JSON">
+
+```json
+{
+  "source": {
+    "linode": {
+      "example": {
+        "image": "linode/debian11",
+        "linode_token": "YOUR API TOKEN",
+        "region": "us-east",
+        "instance_type": "g6-nanode-1",
+        "instance_label": "temporary-linode-{{timestamp}}",
+        "image_label": "private-image-{{timestamp}}",
+        "image_description": "My Private Image",
+        "ssh_username": "root"
+      }
+    }
+  },
+  "build": {
+    "sources": [
+      "source.linode.example"
+    ]
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+### Complicated Example
 
 <Tabs>
 <Tab heading="HCL2">


### PR DESCRIPTION
## 📝 Description

A part of effort to align the parcker plugin arguments with the Linode instance creation API.

closes #75 

## Test

You can manually try the the example in the docs.
And
`make test`