### PR TITLE
fix: windows platform tests fail due to fmt

### DIFF
--- a/.github/workflows/go-test-multiplatform.yml
+++ b/.github/workflows/go-test-multiplatform.yml
@@ -15,9 +15,6 @@ on:
 permissions:
   contents: read
 
-env:
-  REPORT_FILENAME:
-
 jobs:
   get-go-version:
     runs-on: ubuntu-latest
@@ -55,9 +52,10 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
+      # Running unit tests directly with `go test` due to gofmt/gofumpt issues in Windows
       - run: |
           echo "Testing with Go ${{ needs.get-go-version.outputs.go-version }}"
-          make unit-test
+          go test -race -count 1 ./builder/linode/... -timeout=3m -v
 
   linux-go-tests:
     needs:

--- a/.github/workflows/integration-unit-test.yml
+++ b/.github/workflows/integration-unit-test.yml
@@ -6,6 +6,9 @@ on:
       - 'main'
       - 'dev'
 
+env:
+  REPORT_FILENAME:
+
 jobs:
   integration-and-unit-tests:
     runs-on: ubuntu-latest
@@ -41,7 +44,7 @@ jobs:
       - name: Upload test report as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: test-report-${{ github.run_number }}
+          name: test-report-file
           path: "${{ env.REPORT_FILENAME }}"
 
       - name: Test Execution Status Handler
@@ -67,7 +70,7 @@ jobs:
       - name: Download test report
         uses: actions/download-artifact@v4
         with:
-          name: test-report-${{ needs.integration-and-unit-tests.outputs.id }}
+          name: test-report-file
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## 📝 Description

Windows tests are failing because of gofmt issue - https://github.com/linode/packer-plugin-linode/actions/runs/7790781815/job/21245438993

This PR runs the tests directly via `go test`, skipping make fmt step in Windows environment
Note: format/lint is covered in both darwin and ubuntu integraiton/unit tests

## ✔️ How to Test

Refer to comment for green builds for integration and unit tests

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**