### PR TITLE
fix: Issue with darwin-go-test workflow

### DIFF
--- a/.github/workflows/go-test-multiplatform.yml
+++ b/.github/workflows/go-test-multiplatform.yml
@@ -40,7 +40,7 @@ jobs:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - run: |
           echo "Testing with Go ${{ needs.get-go-version.outputs.go-version }}"
-          make unit-test
+          go test -race -count 1 ./builder/linode/... -timeout=3m -v
 
   windows-go-tests:
     needs:


### PR DESCRIPTION
## 📝 Description

The Darwin Go tests keeps failing with an update in Makefile (#205). The outdated Packer version seems the reason for that. Running unit tests directly can fix the issue. 

## ✔️ How to Test

Successful run in forked repo: https://github.com/yec-akamai/packer-plugin-linode/actions/runs/8347997433/job/22848930414?pr=1
