### PR TITLE
Updating API docs to Techdocs

### DIFF
--- a/.web-docs/components/data-source/image/README.md
+++ b/.web-docs/components/data-source/image/README.md
@@ -5,7 +5,7 @@ Linode and private images in your account using regular expression (regex) or an
 match.
 
 You can get the latest list of available public images on Linode via the
-[Linode Image List API](https://www.linode.com/docs/api/images/#images-list).
+[Linode Image List API](https://techdocs.akamai.com/linode-api/reference/get-images).
 
 ## Examples
 

--- a/docs/datasources/image.mdx
+++ b/docs/datasources/image.mdx
@@ -14,7 +14,7 @@ Linode and private images in your account using regular expression (regex) or an
 match.
 
 You can get the latest list of available public images on Linode via the
-[Linode Image List API](https://www.linode.com/docs/api/images/#images-list).
+[Linode Image List API](https://techdocs.akamai.com/linode-api/reference/get-images).
 
 ## Examples
 


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Changes the url pointing to the old linode api docs to techdocs
