### PR TITLE
Add support for `LINODE_CA` env var and `api_ca_path` attribute

### DIFF
--- a/.web-docs/components/builder/linode/README.md
+++ b/.web-docs/components/builder/linode/README.md
@@ -45,6 +45,9 @@ can also be supplied to override the typical auto-generated key:
   `images:read_write`, `linodes:read_write`, and `events:read_only`
   scopes are required for the API token.
 
+- `api_ca_path` (string) - The path to a CA file to trust when making API requests.
+  It can also be specified using the `LINODE_CA` environment variable.
+
 <!-- End of code generated from the comments of the LinodeCommon struct in helper/common.go; -->
 
 <!-- Code generated from the comments of the Config struct in builder/linode/config.go; DO NOT EDIT MANUALLY -->

--- a/.web-docs/components/data-source/image/README.md
+++ b/.web-docs/components/data-source/image/README.md
@@ -69,6 +69,9 @@ data "linode-image" "ubuntu22_lts" {
   `images:read_write`, `linodes:read_write`, and `events:read_only`
   scopes are required for the API token.
 
+- `api_ca_path` (string) - The path to a CA file to trust when making API requests.
+  It can also be specified using the `LINODE_CA` environment variable.
+
 <!-- End of code generated from the comments of the LinodeCommon struct in helper/common.go; -->
 
 

--- a/builder/linode/builder.go
+++ b/builder/linode/builder.go
@@ -39,8 +39,13 @@ func (b *Builder) Prepare(raws ...any) ([]string, []string, error) {
 
 func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook) (ret packersdk.Artifact, err error) {
 	ui.Say("Running builder ...")
+	var client linodego.Client
 
-	client := helper.NewLinodeClient(b.config.PersonalAccessToken)
+	if b.config.APICAPath != "" {
+		client = helper.NewLinodeClientWithCA(b.config.PersonalAccessToken, b.config.APICAPath)
+	} else {
+		client = helper.NewLinodeClient(b.config.PersonalAccessToken)
+	}
 
 	state := new(multistep.BasicStateBag)
 	state.Put("config", &b.config)

--- a/builder/linode/builder.go
+++ b/builder/linode/builder.go
@@ -39,10 +39,13 @@ func (b *Builder) Prepare(raws ...any) ([]string, []string, error) {
 
 func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook) (ret packersdk.Artifact, err error) {
 	ui.Say("Running builder ...")
-	var client linodego.Client
+	var client *linodego.Client
 
 	if b.config.APICAPath != "" {
-		client = helper.NewLinodeClientWithCA(b.config.PersonalAccessToken, b.config.APICAPath)
+		client, err = helper.NewLinodeClientWithCA(b.config.PersonalAccessToken, b.config.APICAPath)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		client = helper.NewLinodeClient(b.config.PersonalAccessToken)
 	}
@@ -95,7 +98,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	artifact := Artifact{
 		ImageLabel: image.Label,
 		ImageID:    image.ID,
-		Driver:     &client,
+		Driver:     client,
 		StateData: map[string]any{
 			"generated_data": state.Get("generated_data"),
 			"source_image":   b.config.Image,

--- a/builder/linode/config.go
+++ b/builder/linode/config.go
@@ -186,6 +186,10 @@ func (c *Config) Prepare(raws ...any) ([]string, error) {
 		c.PersonalAccessToken = os.Getenv("LINODE_TOKEN")
 	}
 
+	if c.APICAPath == "" {
+		c.APICAPath = os.Getenv("LINODE_CA")
+	}
+
 	if c.ImageLabel == "" {
 		if def, err := interpolate.Render("packer-{{timestamp}}", nil); err == nil {
 			c.ImageLabel = def

--- a/builder/linode/config.hcl2spec.go
+++ b/builder/linode/config.hcl2spec.go
@@ -19,6 +19,7 @@ type FlatConfig struct {
 	PackerUserVars            map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars       []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
 	PersonalAccessToken       *string           `mapstructure:"linode_token" cty:"linode_token" hcl:"linode_token"`
+	APICAPath                 *string           `mapstructure:"api_ca_path" cty:"api_ca_path" hcl:"api_ca_path"`
 	Type                      *string           `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect        *string           `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
 	SSHHost                   *string           `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
@@ -111,6 +112,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_user_variables":        &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables":   &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
 		"linode_token":                 &hcldec.AttrSpec{Name: "linode_token", Type: cty.String, Required: false},
+		"api_ca_path":                  &hcldec.AttrSpec{Name: "api_ca_path", Type: cty.String, Required: false},
 		"communicator":                 &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":      &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},
 		"ssh_host":                     &hcldec.AttrSpec{Name: "ssh_host", Type: cty.String, Required: false},

--- a/builder/linode/step_create_image.go
+++ b/builder/linode/step_create_image.go
@@ -10,7 +10,7 @@ import (
 )
 
 type stepCreateImage struct {
-	client linodego.Client
+	client *linodego.Client
 }
 
 func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {

--- a/builder/linode/step_create_linode.go
+++ b/builder/linode/step_create_linode.go
@@ -11,7 +11,7 @@ import (
 )
 
 type stepCreateLinode struct {
-	client linodego.Client
+	client *linodego.Client
 }
 
 func flattenConfigInterfaceIPv4(i *InterfaceIPv4) *linodego.VPCIPv4 {

--- a/builder/linode/step_shutdown_linode.go
+++ b/builder/linode/step_shutdown_linode.go
@@ -10,7 +10,7 @@ import (
 )
 
 type stepShutdownLinode struct {
-	client linodego.Client
+	client *linodego.Client
 }
 
 func (s *stepShutdownLinode) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {

--- a/datasource/image/data.go
+++ b/datasource/image/data.go
@@ -129,10 +129,14 @@ func (d *Datasource) OutputSpec() hcldec.ObjectSpec {
 }
 
 func (d *Datasource) Execute() (cty.Value, error) {
-	var client linodego.Client
+	var client *linodego.Client
+	var err error
 
 	if d.config.APICAPath != "" {
-		client = helper.NewLinodeClientWithCA(d.config.PersonalAccessToken, d.config.APICAPath)
+		client, err = helper.NewLinodeClientWithCA(d.config.PersonalAccessToken, d.config.APICAPath)
+		if err != nil {
+			return cty.NullVal(cty.EmptyObject), err
+		}
 	} else {
 		client = helper.NewLinodeClient(d.config.PersonalAccessToken)
 	}

--- a/datasource/image/data.go
+++ b/datasource/image/data.go
@@ -129,7 +129,13 @@ func (d *Datasource) OutputSpec() hcldec.ObjectSpec {
 }
 
 func (d *Datasource) Execute() (cty.Value, error) {
-	client := helper.NewLinodeClient(d.config.PersonalAccessToken)
+	var client linodego.Client
+
+	if d.config.APICAPath != "" {
+		client = helper.NewLinodeClientWithCA(d.config.PersonalAccessToken, d.config.APICAPath)
+	} else {
+		client = helper.NewLinodeClient(d.config.PersonalAccessToken)
+	}
 
 	filters := linodego.Filter{}
 

--- a/datasource/image/data.hcl2spec.go
+++ b/datasource/image/data.hcl2spec.go
@@ -19,6 +19,7 @@ type FlatConfig struct {
 	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
 	PersonalAccessToken *string           `mapstructure:"linode_token" cty:"linode_token" hcl:"linode_token"`
+	APICAPath           *string           `mapstructure:"api_ca_path" cty:"api_ca_path" hcl:"api_ca_path"`
 	Label               *string           `mapstructure:"label" cty:"label" hcl:"label"`
 	LabelRegex          *string           `mapstructure:"label_regex" cty:"label_regex" hcl:"label_regex"`
 	ID                  *string           `mapstructure:"id" cty:"id" hcl:"id"`
@@ -47,6 +48,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_user_variables":      &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
 		"linode_token":               &hcldec.AttrSpec{Name: "linode_token", Type: cty.String, Required: false},
+		"api_ca_path":                &hcldec.AttrSpec{Name: "api_ca_path", Type: cty.String, Required: false},
 		"label":                      &hcldec.AttrSpec{Name: "label", Type: cty.String, Required: false},
 		"label_regex":                &hcldec.AttrSpec{Name: "label_regex", Type: cty.String, Required: false},
 		"id":                         &hcldec.AttrSpec{Name: "id", Type: cty.String, Required: false},

--- a/helper/client.go
+++ b/helper/client.go
@@ -1,8 +1,12 @@
 package helper
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 
 	"github.com/linode/linodego"
 	"github.com/linode/packer-plugin-linode/version"
@@ -11,14 +15,31 @@ import (
 
 const TokenEnvVar = "LINODE_TOKEN"
 
-func NewLinodeClient(token string) linodego.Client {
-	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-
-	oauthTransport := &oauth2.Transport{
-		Source: tokenSource,
+// AddRootCAToTransport applies the CA at the given path to the given *http.Transport
+func AddRootCAToTransport(CAPath string, transport *http.Transport) error {
+	CAData, err := os.ReadFile(filepath.Clean(CAPath))
+	if err != nil {
+		return fmt.Errorf("failed to read CA file %s: %w", CAPath, err)
 	}
+
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+	}
+
+	if transport.TLSClientConfig.RootCAs == nil {
+		transport.TLSClientConfig.RootCAs = x509.NewCertPool()
+	}
+
+	transport.TLSClientConfig.RootCAs.AppendCertsFromPEM(CAData)
+
+	return nil
+}
+
+func linodeClientFromTransport(transport http.RoundTripper) linodego.Client {
 	oauth2Client := &http.Client{
-		Transport: oauthTransport,
+		Transport: transport,
 	}
 
 	client := linodego.NewClient(oauth2Client)
@@ -29,4 +50,30 @@ func NewLinodeClient(token string) linodego.Client {
 
 	client.SetUserAgent(userAgent)
 	return client
+}
+
+func getDefaultTransportWithCA(CAPath string) *http.Transport {
+	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
+	AddRootCAToTransport(CAPath, httpTransport)
+
+	return httpTransport
+}
+
+func getOauth2TransportWithToken(token string, baseTransport http.RoundTripper) *oauth2.Transport {
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	oauthTransport := &oauth2.Transport{
+		Source: tokenSource,
+		Base:   baseTransport,
+	}
+	return oauthTransport
+}
+
+func NewLinodeClient(token string) linodego.Client {
+	oauthTransport := getOauth2TransportWithToken(token, nil)
+	return linodeClientFromTransport(oauthTransport)
+}
+
+func NewLinodeClientWithCA(token, CAPath string) linodego.Client {
+	oauthTransport := getOauth2TransportWithToken(token, getDefaultTransportWithCA(CAPath))
+	return linodeClientFromTransport(oauthTransport)
 }

--- a/helper/common.go
+++ b/helper/common.go
@@ -10,4 +10,8 @@ type LinodeCommon struct {
 	// `images:read_write`, `linodes:read_write`, and `events:read_only`
 	// scopes are required for the API token.
 	PersonalAccessToken string `mapstructure:"linode_token"`
+
+	// The path to a CA file to trust when making API requests.
+	// It can also be specified using the `LINODE_CA` environment variable.
+	APICAPath string `mapstructure:"api_ca_path"`
 }


### PR DESCRIPTION
## 📝 Description

Similar to the Terraform PR https://github.com/linode/terraform-provider-linode/pull/1614, adding support for `LINODE_CA` environment var and `api_ca_path` attribute in our packer plugin.

## ✔️ How to Test

### Automated Testing (CA test not included)
```bash
make test
```

### Manual Testing
Put this content in a file called `test.pkr.hcl`
```hcl
locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }

source "linode" "example" {
  image             = "linode/debian11"
  image_description = "My Private Image"
  image_label       = "private-image-${local.timestamp}"
  instance_label    = "temporary-linode-${local.timestamp}"
  instance_type     = "g6-nanode-1"
  region            = "us-east"
  ssh_username      = "root"
  api_ca_path       = "/path/to/your/ca.pem"

  interface {
    purpose = "public"
  }
}

build {
  sources = ["source.linode.example"]
}
```

```bash
make dev
packer build .
```