### PR TITLE
CI: Notify slack channel on release 

### DIFF
--- a/.github/workflows/release-notify-slack.yml
+++ b/.github/workflows/release-notify-slack.yml
@@ -1,0 +1,30 @@
+name: Notify Dev DX Channel on Release
+on:
+  release:
+    types: [published]
+  workflow_dispatch: null
+
+jobs:
+  notify:
+    if: github.repository == 'linode/packer-plugin-linode'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack - Main Message
+        id: main_message
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: ${{ secrets.DEV_DX_SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*New Release Published: _packer-plugin-linode_ <${{ github.event.release.html_url }}|${{ github.event.release.tag_name }}> is now live!* :tada:"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## 📝 Description

Notify `dev-dx` slack channel upon release publication.

Main message announces release notice followed by threaded message for release notes link. Refer to images below

## ✔️ How to Test

Tested on my forked and private channel
E.g.
![image](https://github.com/user-attachments/assets/b0094fb4-0b58-436a-a41f-8d4cecd46c58)


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**