### PR TITLE
Fix VPC interface addresses flattening

### DIFF
--- a/builder/linode/step_create_disk_config_test.go
+++ b/builder/linode/step_create_disk_config_test.go
@@ -534,7 +534,7 @@ func TestFlattenInstanceConfig_AllFields(t *testing.T) {
 			Network:           &trueVal,
 			DevTmpFsAutomount: &trueVal,
 		},
-		Interfaces: []Interface{{Purpose: "public", Primary: true}},
+		Interfaces:  []Interface{{Purpose: "public", Primary: true}},
 		MemoryLimit: 2048,
 		Kernel:      "linode/grub2",
 		InitRD:      44,

--- a/builder/linode/step_create_disk_config_test.go
+++ b/builder/linode/step_create_disk_config_test.go
@@ -1,6 +1,7 @@
 package linode
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -271,19 +272,49 @@ func TestFlattenDisk(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := flattenDisk(tt.disk)
 
-			if got.Label != tt.want.Label {
-				t.Errorf("flattenDisk() Label = %v, want %v", got.Label, tt.want.Label)
-			}
-			if got.Size != tt.want.Size {
-				t.Errorf("flattenDisk() Size = %v, want %v", got.Size, tt.want.Size)
-			}
-			if got.Image != tt.want.Image {
-				t.Errorf("flattenDisk() Image = %v, want %v", got.Image, tt.want.Image)
-			}
-			if got.Filesystem != tt.want.Filesystem {
-				t.Errorf("flattenDisk() Filesystem = %v, want %v", got.Filesystem, tt.want.Filesystem)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("flattenDisk() = %+v, want %+v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFlattenDisk_AllFields(t *testing.T) {
+	disk := Disk{
+		Label:           "boot",
+		Size:            32000,
+		Image:           "linode/ubuntu24.04",
+		Filesystem:      "ext4",
+		AuthorizedKeys:  []string{"ssh-rsa AAAA-test"},
+		AuthorizedUsers: []string{"root", "devops"},
+		StackscriptID:   123,
+		StackscriptData: map[string]string{"foo": "bar"},
+	}
+
+	got := flattenDisk(disk)
+	if got.Label != disk.Label {
+		t.Fatalf("Label = %q, want %q", got.Label, disk.Label)
+	}
+	if got.Size != disk.Size {
+		t.Fatalf("Size = %d, want %d", got.Size, disk.Size)
+	}
+	if got.Image != disk.Image {
+		t.Fatalf("Image = %q, want %q", got.Image, disk.Image)
+	}
+	if got.Filesystem != disk.Filesystem {
+		t.Fatalf("Filesystem = %q, want %q", got.Filesystem, disk.Filesystem)
+	}
+	if len(got.AuthorizedKeys) != 1 || got.AuthorizedKeys[0] != "ssh-rsa AAAA-test" {
+		t.Fatalf("AuthorizedKeys = %v, want [ssh-rsa AAAA-test]", got.AuthorizedKeys)
+	}
+	if len(got.AuthorizedUsers) != 2 || got.AuthorizedUsers[0] != "root" || got.AuthorizedUsers[1] != "devops" {
+		t.Fatalf("AuthorizedUsers = %v, want [root devops]", got.AuthorizedUsers)
+	}
+	if got.StackscriptID != 123 {
+		t.Fatalf("StackscriptID = %d, want 123", got.StackscriptID)
+	}
+	if got.StackscriptData["foo"] != "bar" {
+		t.Fatalf("StackscriptData = %v, want map[foo:bar]", got.StackscriptData)
 	}
 }
 
@@ -437,7 +468,109 @@ func TestFlattenInstanceConfig(t *testing.T) {
 			if opts.Label != tt.config.Label {
 				t.Errorf("flattenInstanceConfig() Label = %v, want %v", opts.Label, tt.config.Label)
 			}
+			if opts.Comments != tt.config.Comments {
+				t.Errorf("flattenInstanceConfig() Comments = %v, want %v", opts.Comments, tt.config.Comments)
+			}
+
+			if tt.config.Devices != nil {
+				if tt.config.Devices.SDA != nil {
+					if opts.Devices.SDA == nil || opts.Devices.SDA.DiskID != diskLabelToID[tt.config.Devices.SDA.DiskLabel] {
+						t.Errorf("flattenInstanceConfig() SDA = %v, want disk id %d", opts.Devices.SDA, diskLabelToID[tt.config.Devices.SDA.DiskLabel])
+					}
+				}
+				if tt.config.Devices.SDB != nil {
+					if opts.Devices.SDB == nil || opts.Devices.SDB.DiskID != diskLabelToID[tt.config.Devices.SDB.DiskLabel] {
+						t.Errorf("flattenInstanceConfig() SDB = %v, want disk id %d", opts.Devices.SDB, diskLabelToID[tt.config.Devices.SDB.DiskLabel])
+					}
+				}
+			}
+
+			if len(opts.Interfaces) != len(tt.config.Interfaces) {
+				t.Errorf("flattenInstanceConfig() Interfaces length = %d, want %d", len(opts.Interfaces), len(tt.config.Interfaces))
+			}
+			for i := range tt.config.Interfaces {
+				if i >= len(opts.Interfaces) {
+					break
+				}
+				if opts.Interfaces[i].Purpose != linodego.ConfigInterfacePurpose(tt.config.Interfaces[i].Purpose) {
+					t.Errorf("flattenInstanceConfig() Interfaces[%d].Purpose = %q, want %q", i, opts.Interfaces[i].Purpose, tt.config.Interfaces[i].Purpose)
+				}
+				if opts.Interfaces[i].Primary != tt.config.Interfaces[i].Primary {
+					t.Errorf("flattenInstanceConfig() Interfaces[%d].Primary = %v, want %v", i, opts.Interfaces[i].Primary, tt.config.Interfaces[i].Primary)
+				}
+			}
+
+			if tt.config.RootDevice == "" {
+				if opts.RootDevice != nil {
+					t.Errorf("flattenInstanceConfig() RootDevice = %v, want nil", opts.RootDevice)
+				}
+			} else {
+				if opts.RootDevice == nil || *opts.RootDevice != tt.config.RootDevice {
+					t.Errorf("flattenInstanceConfig() RootDevice = %v, want %q", opts.RootDevice, tt.config.RootDevice)
+				}
+			}
+
+			if opts.MemoryLimit != tt.config.MemoryLimit || opts.Kernel != tt.config.Kernel || opts.InitRD != tt.config.InitRD || opts.RunLevel != tt.config.RunLevel || opts.VirtMode != tt.config.VirtMode {
+				t.Errorf("flattenInstanceConfig() scalar fields mismatch: got %+v, config %+v", opts, tt.config)
+			}
 		})
+	}
+}
+
+func TestFlattenInstanceConfig_AllFields(t *testing.T) {
+	diskLabelToID := map[string]int{"boot": 101, "swap": 202}
+	trueVal := true
+	cfg := InstanceConfig{
+		Label:    "cfg-all",
+		Comments: "all fields",
+		Devices: &InstanceConfigDevices{
+			SDA: &InstanceConfigDevice{DiskLabel: "boot"},
+			SDB: &InstanceConfigDevice{DiskLabel: "swap"},
+		},
+		Helpers: &InstanceConfigHelpers{
+			UpdateDBDisabled:  &trueVal,
+			Distro:            &trueVal,
+			ModulesDep:        &trueVal,
+			Network:           &trueVal,
+			DevTmpFsAutomount: &trueVal,
+		},
+		Interfaces: []Interface{{Purpose: "public", Primary: true}},
+		MemoryLimit: 2048,
+		Kernel:      "linode/grub2",
+		InitRD:      44,
+		RootDevice:  "/dev/sda",
+		RunLevel:    "default",
+		VirtMode:    "paravirt",
+	}
+
+	opts, err := flattenInstanceConfig(cfg, diskLabelToID)
+	if err != nil {
+		t.Fatalf("flattenInstanceConfig() unexpected error: %v", err)
+	}
+
+	if opts.Label != cfg.Label || opts.Comments != cfg.Comments {
+		t.Fatalf("label/comments = %q/%q, want %q/%q", opts.Label, opts.Comments, cfg.Label, cfg.Comments)
+	}
+	if opts.Devices.SDA == nil || opts.Devices.SDA.DiskID != 101 {
+		t.Fatalf("SDA = %v, want DiskID 101", opts.Devices.SDA)
+	}
+	if opts.Devices.SDB == nil || opts.Devices.SDB.DiskID != 202 {
+		t.Fatalf("SDB = %v, want DiskID 202", opts.Devices.SDB)
+	}
+	if opts.Helpers == nil || !opts.Helpers.UpdateDBDisabled || !opts.Helpers.Distro || !opts.Helpers.ModulesDep || !opts.Helpers.Network || !opts.Helpers.DevTmpFsAutomount {
+		t.Fatalf("helpers = %+v, want all true", opts.Helpers)
+	}
+	if len(opts.Interfaces) != 1 {
+		t.Fatalf("interfaces length = %d, want 1", len(opts.Interfaces))
+	}
+	if opts.Interfaces[0].Purpose != linodego.ConfigInterfacePurpose("public") || !opts.Interfaces[0].Primary {
+		t.Fatalf("interface mapping = %+v, want purpose public primary true", opts.Interfaces[0])
+	}
+	if opts.MemoryLimit != cfg.MemoryLimit || opts.Kernel != cfg.Kernel || opts.InitRD != cfg.InitRD || opts.RunLevel != cfg.RunLevel || opts.VirtMode != cfg.VirtMode {
+		t.Fatalf("scalar config fields not mapped correctly: %+v", opts)
+	}
+	if opts.RootDevice == nil || *opts.RootDevice != cfg.RootDevice {
+		t.Fatalf("RootDevice = %v, want %q", opts.RootDevice, cfg.RootDevice)
 	}
 }
 

--- a/builder/linode/step_create_linode.go
+++ b/builder/linode/step_create_linode.go
@@ -80,7 +80,9 @@ func flattenVPCInterface(vpc *VPCInterface) *linodego.VPCInterfaceCreateOptions 
 		ranges := make([]linodego.VPCInterfaceIPv4RangeCreateOptions, len(vpc.IPv4.Ranges))
 		for i, addr := range vpc.IPv4.Addresses {
 			addresses[i] = linodego.VPCInterfaceIPv4AddressCreateOptions{
-				Address: addr.Address,
+				Address:        addr.Address,
+				Primary:        addr.Primary,
+				NAT1To1Address: addr.NAT1To1Address,
 			}
 		}
 		for i, r := range vpc.IPv4.Ranges {

--- a/builder/linode/step_create_linode_test.go
+++ b/builder/linode/step_create_linode_test.go
@@ -1,0 +1,252 @@
+package linode
+
+import (
+	"testing"
+
+	"github.com/linode/linodego"
+)
+
+func TestFlattenVPCInterface_IPv4AddressFields(t *testing.T) {
+	vpc := &VPCInterface{
+		SubnetID: 12345,
+		IPv4: &VPCInterfaceIPv4{
+			Addresses: []VPCInterfaceIPv4Address{
+				{
+					Address:        linodego.Pointer("auto"),
+					Primary:        linodego.Pointer(true),
+					NAT1To1Address: linodego.Pointer("192.0.2.10"),
+				},
+			},
+			Ranges: []VPCInterfaceIPv4Range{
+				{Range: "10.0.0.0/28"},
+			},
+		},
+	}
+
+	got := flattenVPCInterface(vpc)
+	if got == nil {
+		t.Fatal("flattenVPCInterface() returned nil")
+	}
+	if got.SubnetID != 12345 {
+		t.Fatalf("subnet_id = %d, want 12345", got.SubnetID)
+	}
+	if got.IPv4 == nil {
+		t.Fatal("flattenVPCInterface().IPv4 returned nil")
+	}
+	if got.IPv4.Addresses == nil || len(*got.IPv4.Addresses) != 1 {
+		t.Fatalf("flattenVPCInterface().IPv4.Addresses = %v, want one address", got.IPv4.Addresses)
+	}
+
+	addr := (*got.IPv4.Addresses)[0]
+	if addr.Address == nil || *addr.Address != "auto" {
+		t.Fatalf("address = %v, want auto", addr.Address)
+	}
+	if addr.Primary == nil || *addr.Primary != true {
+		t.Fatalf("primary = %v, want true", addr.Primary)
+	}
+	if addr.NAT1To1Address == nil || *addr.NAT1To1Address != "192.0.2.10" {
+		t.Fatalf("nat_1_1_address = %v, want 192.0.2.10", addr.NAT1To1Address)
+	}
+	if got.IPv4.Ranges == nil || len(*got.IPv4.Ranges) != 1 {
+		t.Fatalf("ranges = %v, want one range", got.IPv4.Ranges)
+	}
+	if (*got.IPv4.Ranges)[0].Range != "10.0.0.0/28" {
+		t.Fatalf("range = %q, want 10.0.0.0/28", (*got.IPv4.Ranges)[0].Range)
+	}
+}
+
+func TestFlattenConfigInterface_AllFields(t *testing.T) {
+	vpcIP := &InterfaceIPv4{VPC: "10.0.0.2", NAT1To1: linodego.Pointer("198.51.100.2")}
+	iface := Interface{
+		VLANInterfaceAttributes: VLANInterfaceAttributes{
+			Label:       "eth1",
+			IPAMAddress: "10.0.0.2/24",
+		},
+		VPCInterfaceAttributes: VPCInterfaceAttributes{
+			SubnetID: linodego.Pointer(999),
+			IPv4:     vpcIP,
+			IPRanges: []string{"10.0.0.3/32"},
+		},
+		Purpose: "vpc",
+		Primary: true,
+	}
+
+	got := flattenConfigInterface(iface)
+	if got.IPAMAddress != iface.IPAMAddress {
+		t.Fatalf("ipam_address = %q, want %q", got.IPAMAddress, iface.IPAMAddress)
+	}
+	if got.Label != iface.Label {
+		t.Fatalf("label = %q, want %q", got.Label, iface.Label)
+	}
+	if got.Purpose != linodego.ConfigInterfacePurpose(iface.Purpose) {
+		t.Fatalf("purpose = %q, want %q", got.Purpose, iface.Purpose)
+	}
+	if !got.Primary {
+		t.Fatal("primary = false, want true")
+	}
+	if got.SubnetID == nil || *got.SubnetID != 999 {
+		t.Fatalf("subnet_id = %v, want 999", got.SubnetID)
+	}
+	if got.IPv4 == nil || got.IPv4.VPC != "10.0.0.2" {
+		t.Fatalf("ipv4 = %v, want VPC 10.0.0.2", got.IPv4)
+	}
+	if got.IPv4.NAT1To1 == nil || *got.IPv4.NAT1To1 != "198.51.100.2" {
+		t.Fatalf("nat_1_1 = %v, want 198.51.100.2", got.IPv4.NAT1To1)
+	}
+	if len(got.IPRanges) != 1 || got.IPRanges[0] != "10.0.0.3/32" {
+		t.Fatalf("ip_ranges = %v, want [10.0.0.3/32]", got.IPRanges)
+	}
+}
+
+func TestFlattenPublicInterface_AllFields(t *testing.T) {
+	public := &PublicInterface{
+		IPv4: &PublicInterfaceIPv4{
+			Addresses: []PublicInterfaceIPv4Address{{
+				Address: linodego.Pointer("auto"),
+				Primary: linodego.Pointer(true),
+			}},
+		},
+		IPv6: &PublicInterfaceIPv6{
+			Ranges: []PublicInterfaceIPv6Range{{Range: "/64"}},
+		},
+	}
+
+	got := flattenPublicInterface(public)
+	if got == nil || got.IPv4 == nil || got.IPv6 == nil {
+		t.Fatalf("flattenPublicInterface() = %v, want non-nil ipv4 and ipv6", got)
+	}
+	if got.IPv4.Addresses == nil || len(*got.IPv4.Addresses) != 1 {
+		t.Fatalf("ipv4 addresses = %v, want one address", got.IPv4.Addresses)
+	}
+	addr := (*got.IPv4.Addresses)[0]
+	if addr.Address == nil || *addr.Address != "auto" {
+		t.Fatalf("ipv4 address = %v, want auto", addr.Address)
+	}
+	if addr.Primary == nil || !*addr.Primary {
+		t.Fatalf("ipv4 primary = %v, want true", addr.Primary)
+	}
+	if got.IPv6.Ranges == nil || len(*got.IPv6.Ranges) != 1 || (*got.IPv6.Ranges)[0].Range != "/64" {
+		t.Fatalf("ipv6 ranges = %v, want [/64]", got.IPv6.Ranges)
+	}
+}
+
+func TestFlattenLinodeInterface_AllFields(t *testing.T) {
+	fw := 123
+	li := LinodeInterface{
+		FirewallID: &fw,
+		DefaultRoute: &InterfaceDefaultRoute{
+			IPv4: linodego.Pointer(true),
+			IPv6: linodego.Pointer(false),
+		},
+		Public: &PublicInterface{
+			IPv4: &PublicInterfaceIPv4{
+				Addresses: []PublicInterfaceIPv4Address{{Address: linodego.Pointer("auto")}},
+			},
+		},
+		VPC: &VPCInterface{SubnetID: 99},
+		VLAN: &VLANInterface{
+			VLANLabel:   "vlan-1",
+			IPAMAddress: linodego.Pointer("10.0.0.1/24"),
+		},
+	}
+
+	got := flattenLinodeInterface(li)
+	if got.FirewallID == nil || *got.FirewallID == nil || **got.FirewallID != 123 {
+		t.Fatalf("firewall_id = %v, want 123", got.FirewallID)
+	}
+	if got.DefaultRoute == nil || got.DefaultRoute.IPv4 == nil || !*got.DefaultRoute.IPv4 {
+		t.Fatalf("default route ipv4 = %v, want true", got.DefaultRoute)
+	}
+	if got.DefaultRoute.IPv6 == nil || *got.DefaultRoute.IPv6 {
+		t.Fatalf("default route ipv6 = %v, want false", got.DefaultRoute.IPv6)
+	}
+	if got.Public == nil {
+		t.Fatalf("public = nil, want non-nil")
+	}
+	if got.Public.IPv4 == nil || got.Public.IPv4.Addresses == nil || len(*got.Public.IPv4.Addresses) != 1 {
+		t.Fatalf("public ipv4 addresses = %v, want one address", got.Public)
+	}
+	if addr := (*got.Public.IPv4.Addresses)[0]; addr.Address == nil || *addr.Address != "auto" {
+		t.Fatalf("public ipv4 address = %v, want auto", addr.Address)
+	}
+	if got.Public.IPv6 != nil {
+		t.Fatalf("public ipv6 = %v, want nil", got.Public.IPv6)
+	}
+	if got.VPC == nil || got.VPC.SubnetID != 99 {
+		t.Fatalf("vpc = %v, want subnet_id 99", got.VPC)
+	}
+	if got.VPC.IPv4 != nil {
+		t.Fatalf("vpc ipv4 = %v, want nil", got.VPC.IPv4)
+	}
+	if got.VLAN == nil || got.VLAN.VLANLabel != "vlan-1" {
+		t.Fatalf("vlan = %v, want label vlan-1", got.VLAN)
+	}
+	if got.VLAN.IPAMAddress == nil || *got.VLAN.IPAMAddress != "10.0.0.1/24" {
+		t.Fatalf("vlan ipam_address = %v, want 10.0.0.1/24", got.VLAN.IPAMAddress)
+	}
+}
+
+func TestFlattenConfigInterfaceIPv4(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		if got := flattenConfigInterfaceIPv4(nil); got != nil {
+			t.Fatalf("flattenConfigInterfaceIPv4(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("maps all fields", func(t *testing.T) {
+		nat := "198.51.100.9"
+		got := flattenConfigInterfaceIPv4(&InterfaceIPv4{
+			VPC:     "10.10.10.2",
+			NAT1To1: &nat,
+		})
+		if got == nil {
+			t.Fatal("flattenConfigInterfaceIPv4() returned nil")
+		}
+		if got.VPC != "10.10.10.2" {
+			t.Fatalf("VPC = %q, want 10.10.10.2", got.VPC)
+		}
+		if got.NAT1To1 == nil || *got.NAT1To1 != nat {
+			t.Fatalf("NAT1To1 = %v, want %q", got.NAT1To1, nat)
+		}
+	})
+}
+
+func TestFlattenVLANInterface(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		if got := flattenVLANInterface(nil); got != nil {
+			t.Fatalf("flattenVLANInterface(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("with and without ipam", func(t *testing.T) {
+		gotNoIPAM := flattenVLANInterface(&VLANInterface{VLANLabel: "vlan-a"})
+		if gotNoIPAM == nil || gotNoIPAM.VLANLabel != "vlan-a" {
+			t.Fatalf("flattenVLANInterface(no ipam) = %v, want label vlan-a", gotNoIPAM)
+		}
+		if gotNoIPAM.IPAMAddress != nil {
+			t.Fatalf("IPAMAddress = %v, want nil", gotNoIPAM.IPAMAddress)
+		}
+
+		ipam := "10.0.0.2/24"
+		gotWithIPAM := flattenVLANInterface(&VLANInterface{VLANLabel: "vlan-b", IPAMAddress: &ipam})
+		if gotWithIPAM == nil || gotWithIPAM.IPAMAddress == nil || *gotWithIPAM.IPAMAddress != ipam {
+			t.Fatalf("flattenVLANInterface(with ipam) = %v, want ipam %q", gotWithIPAM, ipam)
+		}
+	})
+}
+
+func TestFlattenMetadata(t *testing.T) {
+	t.Run("empty userdata returns nil", func(t *testing.T) {
+		if got := flattenMetadata(Metadata{}); got != nil {
+			t.Fatalf("flattenMetadata(empty) = %v, want nil", got)
+		}
+	})
+
+	t.Run("userdata is mapped", func(t *testing.T) {
+		m := Metadata{UserData: "IyEvYmluL2Jhc2gK"}
+		got := flattenMetadata(m)
+		if got == nil || got.UserData != m.UserData {
+			t.Fatalf("flattenMetadata() = %v, want UserData %q", got, m.UserData)
+		}
+	})
+}


### PR DESCRIPTION
## 📝 Description

Fix the issue that NAT 1 to 1 address is not included in creation options after being flattened.

Bug report is from a comment under another issue: https://github.com/linode/packer-plugin-linode/issues/222#issuecomment-3874828177

## ✔️ How to Test
```bash
make unit-test
```