### PR TITLE
TPT-4319: change swap_size to pointer type and update related logic

### DIFF
--- a/.web-docs/components/builder/linode/README.md
+++ b/.web-docs/components/builder/linode/README.md
@@ -88,7 +88,7 @@ can also be supplied to override the typical auto-generated key:
   for more information on the Images available for use. Examples are `linode/debian12`,
   `linode/debian13`, `linode/ubuntu24.04`, `linode/arch`, and `private/12345`.
 
-- `swap_size` (\*int) - The disk size (MiB) allocated for swap space.
+- `swap_size` (int) - The disk size (MiB) allocated for swap space. If omitted, no swap size is sent in the API payload.
 
 - `private_ip` (bool) - If true, the created Linode will have private networking enabled and assigned
   a private IPv4 address.

--- a/.web-docs/components/builder/linode/README.md
+++ b/.web-docs/components/builder/linode/README.md
@@ -88,7 +88,7 @@ can also be supplied to override the typical auto-generated key:
   for more information on the Images available for use. Examples are `linode/debian12`,
   `linode/debian13`, `linode/ubuntu24.04`, `linode/arch`, and `private/12345`.
 
-- `swap_size` (int) - The disk size (MiB) allocated for swap space.
+- `swap_size` (\*int) - The disk size (MiB) allocated for swap space.
 
 - `private_ip` (bool) - If true, the created Linode will have private networking enabled and assigned
   a private IPv4 address.

--- a/.web-docs/components/builder/linode/README.md
+++ b/.web-docs/components/builder/linode/README.md
@@ -88,7 +88,7 @@ can also be supplied to override the typical auto-generated key:
   for more information on the Images available for use. Examples are `linode/debian12`,
   `linode/debian13`, `linode/ubuntu24.04`, `linode/arch`, and `private/12345`.
 
-- `swap_size` (int) - The disk size (MiB) allocated for swap space. If omitted, no swap size is sent in the API payload.
+- `swap_size` (\*int) - The disk size (MiB) allocated for swap space.
 
 - `private_ip` (bool) - If true, the created Linode will have private networking enabled and assigned
   a private IPv4 address.

--- a/builder/linode/builder_test.go
+++ b/builder/linode/builder_test.go
@@ -1027,6 +1027,27 @@ func TestBuilderPrepare_CustomDisksValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("IncompatibleSwapSizeZero", func(t *testing.T) {
+		var b Builder
+		config := testConfig()
+		delete(config, "image")
+		config["swap_size"] = 0
+		config["disk"] = []map[string]any{
+			{"label": "boot", "size": 25000, "image": "linode/arch"},
+		}
+		config["config"] = []map[string]any{
+			{"label": "my-config"},
+		}
+
+		_, _, err := b.Prepare(config)
+		if err == nil {
+			t.Fatal("expected error with swap_size=0 and custom disks")
+		}
+		if !strings.Contains(err.Error(), "swap_size cannot be specified when using custom disks") {
+			t.Fatalf("expected specific error message, got: %s", err)
+		}
+	})
+
 	t.Run("IncompatibleStackScriptID", func(t *testing.T) {
 		var b Builder
 		config := testConfig()

--- a/builder/linode/builder_test.go
+++ b/builder/linode/builder_test.go
@@ -123,6 +123,44 @@ func TestBuilderPrepare_Size(t *testing.T) {
 	}
 }
 
+func TestBuilderPrepare_SwapSize(t *testing.T) {
+	t.Run("omitted remains nil", func(t *testing.T) {
+		var b Builder
+		config := testConfig()
+		delete(config, "swap_size")
+
+		_, warnings, err := b.Prepare(config)
+		if len(warnings) > 0 {
+			t.Fatalf("bad: %#v", warnings)
+		}
+		if err != nil {
+			t.Fatalf("should not have error: %s", err)
+		}
+
+		if b.config.SwapSize != nil {
+			t.Fatalf("swap_size = %v, want nil", b.config.SwapSize)
+		}
+	})
+
+	t.Run("explicit zero remains non-nil", func(t *testing.T) {
+		var b Builder
+		config := testConfig()
+		config["swap_size"] = 0
+
+		_, warnings, err := b.Prepare(config)
+		if len(warnings) > 0 {
+			t.Fatalf("bad: %#v", warnings)
+		}
+		if err != nil {
+			t.Fatalf("should not have error: %s", err)
+		}
+
+		if b.config.SwapSize == nil || *b.config.SwapSize != 0 {
+			t.Fatalf("swap_size = %v, want pointer to 0", b.config.SwapSize)
+		}
+	})
+}
+
 func TestBuilderPrepare_Image(t *testing.T) {
 	var b Builder
 	config := testConfig()

--- a/builder/linode/config.go
+++ b/builder/linode/config.go
@@ -720,7 +720,7 @@ func (c *Config) Prepare(raws ...any) ([]string, error) {
 				errs, errors.New("authorized_users cannot be specified when using custom disks (specify in disk blocks instead)"))
 		}
 
-		if c.SwapSize != nil && *c.SwapSize > 0 {
+		if c.SwapSize != nil {
 			errs = packersdk.MultiErrorAppend(
 				errs, errors.New("swap_size cannot be specified when using custom disks (create a swap disk instead)"))
 		}

--- a/builder/linode/config.go
+++ b/builder/linode/config.go
@@ -288,7 +288,7 @@ type Config struct {
 	Image string `mapstructure:"image" required:"false"`
 
 	// The disk size (MiB) allocated for swap space.
-	SwapSize int `mapstructure:"swap_size" required:"false"`
+	SwapSize *int `mapstructure:"swap_size" required:"false"`
 
 	// If true, the created Linode will have private networking enabled and assigned
 	// a private IPv4 address.
@@ -720,7 +720,7 @@ func (c *Config) Prepare(raws ...any) ([]string, error) {
 				errs, errors.New("authorized_users cannot be specified when using custom disks (specify in disk blocks instead)"))
 		}
 
-		if c.SwapSize > 0 {
+		if c.SwapSize != nil && *c.SwapSize > 0 {
 			errs = packersdk.MultiErrorAppend(
 				errs, errors.New("swap_size cannot be specified when using custom disks (create a swap disk instead)"))
 		}

--- a/builder/linode/step_create_linode.go
+++ b/builder/linode/step_create_linode.go
@@ -168,7 +168,7 @@ func (s *stepCreateLinode) Run(ctx context.Context, state multistep.StateBag) mu
 	if !useCustomDisks {
 		createOpts.RootPass = c.Comm.Password()
 		createOpts.Image = c.Image
-		createOpts.SwapSize = &c.SwapSize
+		createOpts.SwapSize = c.SwapSize
 		createOpts.StackScriptID = c.StackScriptID
 		createOpts.StackScriptData = c.StackScriptData
 


### PR DESCRIPTION
## 📝 Description

When swap_size is not configured, we should not include it in the request payload. Update it to be a pointer type to achieve it.

## ✔️ How to Test
```bash
make unit-test
```