### PR TITLE
TPT-4444: Fix Go version mismatch in Packer release CI workflows

### DIFF
--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -20,10 +20,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
+
       # Ensure that Docs are Compiled
       - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
       - shell: bash
         run: make generate
+
       - shell: bash
         run: |
           if [[ -z "$(git status -s)" ]]; then

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -24,10 +24,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
+
       # Ensure that Docs are Compiled
       - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
       - shell: bash
         run: make generate
+
       - shell: bash
         run: |
           if [[ -z "$(git status -s)" ]]; then
@@ -37,12 +42,14 @@ jobs:
             echo "Run 'make generate', and commit the result to resolve this error."
             exit 1
           fi
+
       # Perform the Release
       - name: Checkout integration-release-action
         uses: actions/checkout@v6
         with:
           repository: hashicorp/integration-release-action
           path: ./integration-release-action
+
       - name: Notify Release
         uses: ./integration-release-action
         with:


### PR DESCRIPTION
## 📝 Description

This PR resolves an issue that caused the oldest support Go release version (v1.24.X) to be installed in the release CI workflow when the project's `go.mod` requires the latest Go version (v1.25.X).

## ✔️ How to Test

Example workflow run, 401 expected because workflow ran on fork: https://github.com/lgarber-akamai/packer-plugin-linode/actions/runs/25929582215/job/76219752420